### PR TITLE
Update rest interface to log in ECS format.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.9.0
-      - image: ukti/docker-clamav:latest
-
+      - image: gcr.io/sre-docker-registry/github.com/uktrade/docker-clamav:master
+        environment:
+          MIRROR_URL: db.local.clamav.net
     steps:
       - checkout
 
@@ -20,9 +21,9 @@ jobs:
             pip install -r requirements.txt
 
       - run:
-          name: Wait for clamav container
+          name: Wait up to 120 seconds for clamav container to start
           command: |
-            for i in `seq 1 30`;
+            for i in `seq 1 120`;
             do
               nc -z localhost 3310 && echo Success && exit 0
               echo -n .

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The usage examples below allow show you how to `curl` the service listening on
 if you want to interact with the service from another locally running docker-compose
 project.
 
+### Environment Variable: MIRROR_URL
+Note that the [clamav docker container](https://github.com/uktrade/docker-clamav) used by this service requires that the env var [MIRROR_URL](https://github.com/uktrade/docker-clamav/blob/a940abae307d1feb3322462e6e229a96fae257a3/debian/buster/custom-bootstrap.sh#L12) is set, otherwise the following error occurs in the `clamd` service:
+```
+ERROR: Missing argument for option at /etc/clamav/freshclam.conf
+ERROR: Can't open/parse the config file /etc/clamav/freshclam.conf
+```
+If using this container, ensure the `MIRROR_URL` env var is set in the docker-compose file.
+
 ## Service health
 The following URIs (using a docker compose setup with NGINX proxy listening on
 port 80) do not require authentication and perform a basic service health

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -218,14 +218,6 @@ def after_request(response):
             "http.request.body.content": None,
             "http.request.body.bytes": 0
         }
-    try:
-    labels={**labels,
-            "http.version": request.environ.get('SERVER_PROTOCOL')
-        }
-    except:
-        labels={**labels,
-            "http.version": None,
-        }
     labels={**labels,
         "http.request.method": getattr(request, 'method', None),
         "http.request.bytes": getattr(request, 'content_length', None),

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import ecs_logging
 import sys
 import timeit
 import uuid
@@ -14,9 +15,12 @@ from raven.contrib.flask import Sentry
 import clamav_versions as versions
 from version import __version__
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-
 logger = logging.getLogger("CLAMAV-REST")
+
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setFormatter(ecs_logging.StdlibFormatter())
+logger.addHandler(handler)
 
 app = Flask("CLAMAV-REST")
 app.config.from_object(os.environ["APP_CONFIG"])

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -209,14 +209,12 @@ def request_entity_too_large(error):
 def after_request(response):
     """ Logging after every request. """
     zipkin_headers = ("X-B3-Traceid", "X-B3-Spanid")
-    extra_labels = {"X-B3-Traceid": "none", "X-B3-Spanid": "none"}
+    labels = {"X-B3-Traceid": "none", "X-B3-Spanid": "none"}
     for header in request.headers:
         if header[0] in zipkin_headers:
-            extra_labels[header[0]] = header[1]
-    labels={
-        "trace.id": extra_labels["X-B3-Traceid"],
-        "span.id": extra_labels["X-B3-Spanid"]
-    }
+            labels[header[0]] = header[1]
+    labels["trace.id"] = labels["X-B3-Traceid"]
+    labels["span.id"] = labels["X-B3-Spanid"]
     try:
         labels={**labels,
             "http.request.body.content": request.data,
@@ -227,36 +225,28 @@ def after_request(response):
             "http.request.body.content": None,
             "http.request.body.bytes": 0
         }
-    try:
-        labels={**labels,
-            "http.version": request.environ.get('SERVER_PROTOCOL')
-        }
-    except:
-        labels={**labels,
-            "http.version": None,
-        }
-    labels={**labels,
-        "http.request.method": getattr(request, 'method', None),
-        "http.request.bytes": getattr(request, 'content_length', None),
-        "http.request.mime_type": getattr(request, 'mimetype', None),
-        "http.request.referrer": getattr(request, 'referrer', None),
-        "http.response.status_code": getattr(response, 'status_code', None),
-        "http.response.bytes": getattr(response, 'content_length', None),
-        "http.response.body.content": getattr(response, 'data', None),
-        "http.response.body.bytes": len(getattr(response, 'data', None)),
-        "http.response.mime_type": getattr(response, 'mimetype', None),
-        "source.ip": getattr(request, 'remote_addr', None),
-        "url.path": getattr(request, 'path', None),
-        "url.original": getattr(request, 'url', None),
-        "url.domain": getattr(request, 'host', None),
-        "url.scheme": getattr(request, 'scheme', None),
-        "user_agent.original": getattr(request, 'user_agent', None)
-    }
+    labels["http.request.method"] = getattr(request, 'method', None)
+    labels["http.request.bytes"] = getattr(request, 'content_length', None)
+    labels["http.request.mime_type"] = getattr(request, 'mimetype', None)
+    labels["http.request.referrer"] = getattr(request, 'referrer', None)
+    labels["http.response.status_code"] = getattr(response, 'status_code', None)
+    labels["http.response.bytes"] = getattr(response, 'content_length', None)
+    labels["http.response.body.content"] = getattr(response, 'data', None)
+    labels["http.response.body.bytes"] = len(getattr(response, 'data', None))
+    labels["http.response.mime_type"] = getattr(response, 'mimetype', None)
+    labels["http.version"] = request.environ.get("SERVER_PROTOCOL", None)
+    labels["source.ip"] = getattr(request, 'remote_addr', None)
+    labels["url.path"] = getattr(request, 'path', None)
+    labels["url.original"] = getattr(request, 'url', None)
+    labels["url.domain"] = getattr(request, 'host', None)
+    labels["url.scheme"] = getattr(request, 'scheme', None)
+    labels["user_agent.original"] = getattr(request, 'user_agent', None)
+    
     logger.info(
         "%s %s",
         __name__,
         request.endpoint,
-        extra={**labels,**extra_labels}
+        extra=labels
     )
     return response
 

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -218,6 +218,14 @@ def after_request(response):
             "http.request.body.content": None,
             "http.request.body.bytes": 0
         }
+    try:
+        labels={**labels,
+            "http.version": request.environ.get('SERVER_PROTOCOL')
+        }
+    except:
+        labels={**labels,
+            "http.version": None,
+        }
     labels={**labels,
         "http.request.method": getattr(request, 'method', None),
         "http.request.bytes": getattr(request, 'content_length', None),

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -16,11 +16,20 @@ import clamav_versions as versions
 from version import __version__
 
 logger = logging.getLogger("CLAMAV-REST")
-
 logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(stream=sys.stdout)
-handler.setFormatter(ecs_logging.StdlibFormatter())
-logger.addHandler(handler)
+
+# Warnings and above log to the stderr stream
+stderr_handler = logging.StreamHandler(stream=sys.stderr)
+stderr_handler.setLevel(logging.WARNING)
+stderr_handler.setFormatter(ecs_logging.StdlibFormatter())
+logger.addHandler(stderr_handler)
+
+# Events below Warning log to the stdout stream
+stdout_handler = logging.StreamHandler(stream=sys.stdout)
+stdout_handler.setLevel(logging.DEBUG)
+stdout_handler.addFilter(lambda record: record.levelno < logging.WARNING)
+stdout_handler.setFormatter(ecs_logging.StdlibFormatter())
+logger.addHandler(stdout_handler)
 
 app = Flask("CLAMAV-REST")
 app.config.from_object(os.environ["APP_CONFIG"])

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -208,15 +208,10 @@ def request_entity_too_large(error):
 @app.after_request
 def after_request(response):
     """ Logging after every request. """
+
     labels = {}
 
-    # Store the zipkin headers in the same fields as django-log-formatter-ecs
-    labels["X-B3-Traceid"] = request.headers.get("X-B3-Traceid", "none")
-    labels["X-B3-Spanid"] = request.headers.get("X-B3-Spanid", "none")
-    # Also store zipkin headers in the standard ECS fields
-    labels["trace.id"] = labels["X-B3-Traceid"]
-    labels["span.id"] = labels["X-B3-Spanid"]
-
+    # Store the general flask request and response values in standard ECS structure
     labels["http.request.method"] = getattr(request, 'method', None)
     labels["http.request.bytes"] = getattr(request, 'content_length', None)
     labels["http.request.mime_type"] = getattr(request, 'mimetype', None)
@@ -234,6 +229,14 @@ def after_request(response):
     labels["url.scheme"] = getattr(request, 'scheme', None)
     labels["user_agent.original"] = getattr(request, 'user_agent', None)
     
+
+    # Store the zipkin headers in the same fields as django-log-formatter-ecs
+    labels["X-B3-Traceid"] = request.headers.get("X-B3-Traceid", "none")
+    labels["X-B3-Spanid"] = request.headers.get("X-B3-Spanid", "none")
+    # Also store zipkin headers in the standard ECS fields
+    labels["trace.id"] = labels["X-B3-Traceid"]
+    labels["span.id"] = labels["X-B3-Spanid"]
+
     # Don't try to read request.data when request entity is too large
     if labels["http.response.status_code"] != 413:
         labels["http.request.body.content"] = getattr(request, 'data', None)

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -228,7 +228,6 @@ def after_request(response):
     labels["url.domain"] = getattr(request, 'host', None)
     labels["url.scheme"] = getattr(request, 'scheme', None)
     labels["user_agent.original"] = getattr(request, 'user_agent', None)
-    
 
     # Store the zipkin headers in the same fields as django-log-formatter-ecs
     labels["X-B3-Traceid"] = request.headers.get("X-B3-Traceid", "none")

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -199,8 +199,13 @@ def request_entity_too_large(error):
 @app.after_request
 def after_request(response):
     """ Logging after every request. """
+    extra_labels = {}
+    zipkin_headers = ("X-B3-Traceid", "X-B3-Spanid")
+    for header in request.headers:
+        if header[0] in zipkin_headers:
+            extra_labels[header[0]] = header[1]
     logger.info(
-        "%s [%s] %s %s %s %s %s %s %s %s",
+        "%s [%s] %s %s %s %s %s %s %s",
         request.remote_addr,
         datetime.utcnow().strftime("%d/%b/%Y:%H:%M:%S.%f")[:-3],
         request.method,
@@ -210,7 +215,7 @@ def after_request(response):
         response.content_length,
         request.referrer,
         request.user_agent,
-        request.headers,
+        extra=extra_labels
     )
     return response
 

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -18,7 +18,7 @@ from version import __version__
 logger = logging.getLogger("CLAMAV-REST")
 
 logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
+handler = logging.StreamHandler(stream=sys.stdout)
 handler.setFormatter(ecs_logging.StdlibFormatter())
 logger.addHandler(handler)
 

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -204,10 +204,22 @@ def after_request(response):
         if header[0] in zipkin_headers:
             extra_labels[header[0]] = header[1]
     labels={
+        "trace.id": extra_labels["X-B3-Traceid"],
+        "span.id": extra_labels["X-B3-Spanid"]
+    }
+    try:
+        labels={**labels,
+            "http.request.body.content": request.data,
+            "http.request.body.bytes": len(request.data)
+        }
+    except:
+        labels={**labels,
+            "http.request.body.content": "none",
+            "http.request.body.bytes": 0
+        }
+    labels={**labels,
         "http.request.method": request.method,
         "http.request.bytes":request.content_length,
-        "http.request.body.content": request.data,
-        "http.request.body.bytes": len(request.data),
         "http.request.mime_type": request.mimetype,
         "http.request.referrer": request.referrer,
         "http.response.status_code": response.status_code,
@@ -221,9 +233,7 @@ def after_request(response):
         "url.original":request.url,
         "url.domain": request.host,
         "url.scheme": request.scheme,
-        "user_agent.original": request.user_agent,
-        "trace.id": extra_labels["X-B3-Traceid"],
-        "span.id": extra_labels["X-B3-Spanid"]
+        "user_agent.original": request.user_agent
     }
     logger.info(
         "%s %s",

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import ecs_logging
+from datetime import datetime 
 import sys
 import timeit
 import uuid
@@ -194,6 +195,24 @@ def request_entity_too_large(error):
     """
     logger.warning(f"{error}")
     return "File Too Large", 413
+
+@app.after_request
+def after_request(response):
+    """ Logging after every request. """
+    logger.info(
+        "%s [%s] %s %s %s %s %s %s %s %s",
+        request.remote_addr,
+        datetime.utcnow().strftime("%d/%b/%Y:%H:%M:%S.%f")[:-3],
+        request.method,
+        request.path,
+        request.scheme,
+        response.status,
+        response.content_length,
+        request.referrer,
+        request.user_agent,
+        request.headers,
+    )
+    return response
 
 
 #

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -195,6 +195,7 @@ def request_entity_too_large(error):
     logger.warning(f"{error}")
     return "File Too Large", 413
 
+
 @app.after_request
 def after_request(response):
     """ Logging after every request. """

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -16,7 +16,7 @@ import clamav_versions as versions
 from version import __version__
 
 logger = logging.getLogger("CLAMAV-REST")
-logger.setLevel(logging.DEBUG)
+logger.setLevel(os.environ.get("LOGGING_LEVEL", logging.DEBUG))
 
 # Warnings and above log to the stderr stream
 stderr_handler = logging.StreamHandler(stream=sys.stderr)

--- a/clamav_rest.py
+++ b/clamav_rest.py
@@ -215,26 +215,33 @@ def after_request(response):
         }
     except:
         labels={**labels,
-            "http.request.body.content": "none",
+            "http.request.body.content": None,
             "http.request.body.bytes": 0
         }
+    try:
     labels={**labels,
-        "http.request.method": request.method,
-        "http.request.bytes":request.content_length,
-        "http.request.mime_type": request.mimetype,
-        "http.request.referrer": request.referrer,
-        "http.response.status_code": response.status_code,
-        "http.response.bytes": response.content_length,
-        "http.response.body.content": response.data,
-        "http.response.body.bytes": len(response.data),
-        "http.response.mime_type": response.mimetype,
-        "http.version": request.environ.get('SERVER_PROTOCOL'),
-        "source.ip": request.remote_addr,
-        "url.path": request.path,
-        "url.original":request.url,
-        "url.domain": request.host,
-        "url.scheme": request.scheme,
-        "user_agent.original": request.user_agent
+            "http.version": request.environ.get('SERVER_PROTOCOL')
+        }
+    except:
+        labels={**labels,
+            "http.version": None,
+        }
+    labels={**labels,
+        "http.request.method": getattr(request, 'method', None),
+        "http.request.bytes": getattr(request, 'content_length', None),
+        "http.request.mime_type": getattr(request, 'mimetype', None),
+        "http.request.referrer": getattr(request, 'referrer', None),
+        "http.response.status_code": getattr(response, 'status_code', None),
+        "http.response.bytes": getattr(response, 'content_length', None),
+        "http.response.body.content": getattr(response, 'data', None),
+        "http.response.body.bytes": len(getattr(response, 'data', None)),
+        "http.response.mime_type": getattr(response, 'mimetype', None),
+        "source.ip": getattr(request, 'remote_addr', None),
+        "url.path": getattr(request, 'path', None),
+        "url.original": getattr(request, 'url', None),
+        "url.domain": getattr(request, 'host', None),
+        "url.scheme": getattr(request, 'scheme', None),
+        "user_agent.original": getattr(request, 'user_agent', None)
     }
     logger.info(
         "%s %s",

--- a/clamav_versions.py
+++ b/clamav_versions.py
@@ -7,7 +7,6 @@ import logging
 import sys
 
 logger = logging.getLogger("CLAMAV-REST.VERSIONS_SERVICE")
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 class VersionError(Exception):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,6 @@ services:
       - APP_CONFIG=config.TestConfig
   clamd:
     image: gcr.io/sre-docker-registry/github.com/uktrade/docker-clamav:master
+    environment:
+      - MIRROR_URL=db.local.clamav.net
+      

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask-HTTPAuth==4.2.0
 gunicorn==20.0.4
 blinker==1.4
 dnspython==2.1.0
+ecs_logging==1.1.0
 
 # required for tests
 requests==2.25.1

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.5
+python-3.9.7


### PR DESCRIPTION
Makes the following changes:
- Imports the `ecs_logging` package.
- Creates a handler with the ECS Logging formatter.
- Creates an after-request function to translate Flask [request](https://tedboy.github.io/flask/interface_api.incoming_request_data.html#flask.Request) and [response](https://tedboy.github.io/flask/interface_api.response_object.html#flask.Response) object values to [ECS Field](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) standards and log to the logger.
- Reads tracing headers from request and log to [ECS Tracing](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html) fields.
  -  Also log to top-level fields as used in the [django-log-formatter-ecs](https://github.com/uktrade/django-log-formatter-ecs) module.
- Updates CircleCI config to use clamav image in GCR (changed from Dockerhub image).
- Add 'try' blocks to logging function.