### PR TITLE
Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ raven==6.10.0
 passlib==1.7.4
 Flask-HTTPAuth==4.8.0
 Werkzeug>=3.0.3
-gunicorn>=22.0.0
+gunicorn==21.2.0
 blinker==1.6.3
 dnspython==2.4.2
 ecs_logging==2.1.0
 
 # required for tests
-requests==2.31.0
+requests>=2.32.0
 Flask-Testing==0.8.1
 locust==2.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ raven==6.10.0
 passlib==1.7.4
 Flask-HTTPAuth==4.8.0
 Werkzeug>=3.0.3
-gunicorn>=22.0.0
+gunicorn==21.2.0
 blinker==1.6.3
-dnspython>=2.6.1
+dnspython==2.4.2
 ecs_logging==2.1.0
 
 # required for tests
-requests>=2.32.0
+requests==2.31.0
 Flask-Testing==0.8.1
 locust==2.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-HTTPAuth==4.8.0
 Werkzeug>=3.0.3
 gunicorn==21.2.0
 blinker==1.6.3
-dnspython==2.4.2
+dnspython>=2.6.1
 ecs_logging==2.1.0
 
 # required for tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ raven==6.10.0
 passlib==1.7.4
 Flask-HTTPAuth==4.8.0
 Werkzeug>=3.0.3
-gunicorn==21.2.0
+gunicorn>=22.0.0
 blinker==1.6.3
 dnspython==2.4.2
 ecs_logging==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ flask==3.0.0
 raven==6.10.0
 passlib==1.7.4
 Flask-HTTPAuth==4.8.0
-Werkzeug==3.0.1
-gunicorn==21.2.0
+Werkzeug>=3.0.3
+gunicorn>=22.0.0
 blinker==1.6.3
-dnspython==2.4.2
+dnspython>=2.6.1
 ecs_logging==2.1.0
 
 # required for tests
-requests==2.31.0
+requests>=2.32.0
 Flask-Testing==0.8.1
 locust==2.17.0


### PR DESCRIPTION
updated werkzeug, requests and dnspython.
Gunicorn is a major update, and causes an error in ci tests.  This will be worked on seperately.